### PR TITLE
disabling the proportional line on selected groups

### DIFF
--- a/catcorr.js
+++ b/catcorr.js
@@ -291,9 +291,12 @@
                             return v;
                         });
 
-                    // render the .all_proportion.all_bar to show the proportion of
-                    g.selectAll(".all_proportion.all_bar")
-                        .attr("d", proportionPath);
+                    // render the .all_proportion.all_bar to show the
+                    // proportion of
+		    if (brush.empty()) {
+			g.selectAll(".all_proportion.all_bar")
+                            .attr("d", proportionPath);
+		    }
 
                 });
 


### PR DESCRIPTION
why does the white line show up. kinda wierd, says @ahwolf
